### PR TITLE
Add support for Heroku

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@
 
 You could also install docker and use the docker file to run sdbot.
 
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+
 ## Prerequisites
 When you run `make run` it'll try to install matplotlib. Matplotlib depends on `libpng`, `pkg-config` and `freetype`. These needs to be installed before you can install matplotlib. 
 

--- a/app.json
+++ b/app.json
@@ -1,0 +1,22 @@
+{
+  "name": "SDBot",
+  "description": "A Slack chatbot for Server Density",
+  "keywords": [
+    "slack",
+    "serverdensity"
+  ],
+  "website": "https://www.serverdensity.com/slackbot/",
+  "repository": "https://github.com/serverdensity/sdbot",
+  "logo": "https://www.serverdensity.com/assets/images/slackbot/bot.png",
+  "env": {
+    "SLACK_TOKEN": {
+      "description": "The Slack bot Auth Token"
+    },
+    "SD_AUTH_TOKEN": {
+      "description": "The Server Density Auth Token"
+    },
+    "SD_ACCOUNT_NAME": {
+      "description": "The account name you at Server Density ie myaccount in myaccount.serverdensity.io"
+    }
+  }
+}


### PR DESCRIPTION
* Heroku will automatically detect that this is a python app and will install all dependencies with `pip`
* Heroku will use the `Procfile` to start a worker

If you click on the deploy to Heroku button, you'll see this screen:

![screenshot 2016-02-27 11 10 59](https://cloud.githubusercontent.com/assets/3886384/13372439/22f7aa88-dd43-11e5-8ae5-423740dd71d2.png)

What do you think? Please check if you're okay with the descriptions of the config variables in the app.json file.

:shipit: